### PR TITLE
Fix redundant entrypoint in MainPage

### DIFF
--- a/flutter_application_1/lib/screens/main_page.dart
+++ b/flutter_application_1/lib/screens/main_page.dart
@@ -1,26 +1,9 @@
-// main.dart
+// main_page.dart
 import 'package:flutter/material.dart';
 import 'home_screen.dart';
 import 'part_shop_screen.dart';
 import 'search_screen.dart';
 import 'my_menu_screen.dart';
-
-void main() {
-  runApp(const MyApp());
-}
-
-class MyApp extends StatelessWidget {
-  const MyApp({Key? key}) : super(key: key);
-
-  @override
-  Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'KREAM-like App',
-      theme: ThemeData(primarySwatch: Colors.blue),
-      home: const MainPage(),
-    );
-  }
-}
 
 class MainPage extends StatefulWidget {
   const MainPage({Key? key}) : super(key: key);


### PR DESCRIPTION
## Summary
- clean up `lib/screens/main_page.dart` by removing an unused `main()` and `MyApp`

## Testing
- `flutter --version` *(fails: command not found)*
- `dart format lib/screens/main_page.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fdfa164a483269c1a3ab3a972dc6f