### PR TITLE
Add note about iOS configuration file

### DIFF
--- a/flutter_application_1/README.md
+++ b/flutter_application_1/README.md
@@ -14,3 +14,7 @@ A few resources to get you started if this is your first Flutter project:
 For help getting started with Flutter development, view the
 [online documentation](https://docs.flutter.dev/), which offers tutorials,
 samples, guidance on mobile development, and a full API reference.
+
+### Generated iOS configuration
+
+Running `flutter pub get` generates `ios/Flutter/Generated.xcconfig`. If you encounter configuration issues, delete this file and run `flutter pub get` again to regenerate it.


### PR DESCRIPTION
## Summary
- note that `flutter pub get` generates `ios/Flutter/Generated.xcconfig`
- mention deleting the file and running `flutter pub get` again when issues arise

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ffc52b0708326ba284e6eb9be6efa